### PR TITLE
Migrate scenarios to DAML Scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,22 +175,22 @@ workflows:
   build_and_test:
     jobs:
       - daml_test:
-          daml_sdk_version: "1.4.0"
+          daml_sdk_version: "1.5.0"
       - mvn_test:
-          daml_sdk_version: "1.4.0"
+          daml_sdk_version: "1.5.0"
           bitcoin_cli_version: "0.18.1"
           context: refapps
       - blackduck_check:
-          daml_sdk_version: "1.4.0"
+          daml_sdk_version: "1.5.0"
           context: blackduck
   build_and_release:
     jobs:
       - daml_test:
           <<: *only-release-tags
-          daml_sdk_version: "1.4.0"
+          daml_sdk_version: "1.5.0"
       - mvn_test:
           <<: *only-release-tags
-          daml_sdk_version: "1.4.0"
+          daml_sdk_version: "1.5.0"
           bitcoin_cli_version: "0.18.1"
           context: blackduck
       - github_release:

--- a/Dockerfile-sandbox
+++ b/Dockerfile-sandbox
@@ -2,7 +2,7 @@
 # Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 #
 
-ARG sdk_vsn=1.4.0
+ARG sdk_vsn=1.5.0-snapshot.20200907.5151.0.eb68e680
 
 FROM digitalasset/daml-sdk:${sdk_vsn} AS source
 

--- a/Dockerfile-sandbox
+++ b/Dockerfile-sandbox
@@ -2,7 +2,7 @@
 # Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 #
 
-ARG sdk_vsn=1.5.0-snapshot.20200907.5151.0.eb68e680
+ARG sdk_vsn=1.5.0
 
 FROM digitalasset/daml-sdk:${sdk_vsn} AS source
 

--- a/daml.yaml
+++ b/daml.yaml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-sdk-version: 1.4.0
+sdk-version: 1.5.0-snapshot.20200907.5151.0.eb68e680
 name: inventory-management
 source: src/main/daml/
 init-script: Test.OnboardingScript:onboarding
@@ -15,7 +15,6 @@ parties:
   - ComplianceOfficer
   - SigningParty
 version: 1.0.1
-exposed-modules: []
 dependencies:
   - daml-prim
   - daml-stdlib

--- a/daml.yaml
+++ b/daml.yaml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-sdk-version: 1.5.0-snapshot.20200907.5151.0.eb68e680
+sdk-version: 1.5.0
 name: inventory-management
 source: src/main/daml/
 init-script: Test.OnboardingScript:onboarding

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <daml-sdk.version>1.4.0</daml-sdk.version>
+        <daml-sdk.version>1.5.0-snapshot.20200907.5151.0.eb68e680</daml-sdk.version>
         <daml-plugin.version>0.1.4</daml-plugin.version>
         <slf4j.version>1.7.26</slf4j.version>
         <logback.version>1.2.3</logback.version>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <daml-sdk.version>1.5.0-snapshot.20200907.5151.0.eb68e680</daml-sdk.version>
+        <daml-sdk.version>1.5.0</daml-sdk.version>
         <daml-plugin.version>0.1.4</daml-plugin.version>
         <slf4j.version>1.7.26</slf4j.version>
         <logback.version>1.2.3</logback.version>

--- a/src/main/daml/Test/OnboardingScript.daml
+++ b/src/main/daml/Test/OnboardingScript.daml
@@ -14,13 +14,32 @@ import Actors.DeskHead
 import Actors.Operator
 import Actors.SigningParty
 import Actors.Trader
+import Desk.Limit
 import Bitcoin.Types
 import Transfer.Address
 
 satoshiLimit : Satoshi
 satoshiLimit = Satoshi 100_000_000
 
-onboarding : Script ()
+data ScriptPartiesHelper = ScriptPartiesHelper with
+  operator : Party
+  trader : Party
+  deskHead : Party
+  signingParty : Party
+  complianceOfficer: Party
+
+
+data ScriptContractsHelper = ScriptContractsHelper with
+  oemCid: ContractId OnboardEntityMaster
+  complCid: ContractId ComplianceRole
+  signCid: ContractId SigningPartyRole
+  deskHeadCid: ContractId DeskHeadRole
+  traderCid: ContractId TraderRole
+  limitCid: ContractId TransferLimit
+  addressCid: ContractId DestinationAddress
+  badAddressCid: ContractId DestinationAddress
+
+onboarding : Script (ScriptPartiesHelper, ScriptContractsHelper, BitcoinAddress, BitcoinAddress)
 onboarding = do
   operator <- getParty "Operator"
   trader1 <- getParty "Trader1"
@@ -81,9 +100,11 @@ onboarding = do
   complianceOfficer `submit` exerciseCmd complCid AddObserverToAddress with newObserver = deskHead, addressCid = badAddressCid
 
   -- Issue Desk Limits
-  deskHead `submit` exerciseCmd deskHeadCid IssueTransferLimit with dayLimit = satoshiLimit
+  limitCid <- deskHead `submit` exerciseCmd deskHeadCid IssueTransferLimit with dayLimit = satoshiLimit
 
-  return ()
+  let parties = ScriptPartiesHelper operator trader1 deskHead signingParty complianceOfficer
+  let contracts = ScriptContractsHelper oemCid complCid signCid deskHeadCid trdr1Cid limitCid addressCid badAddressCid
+  return (parties, contracts, address, badAddress1)
 
 -- | Same as `getParty` scenarios but for DAML Scripts.
 getParty: Text -> Script Party

--- a/src/main/daml/Test/Test.daml
+++ b/src/main/daml/Test/Test.daml
@@ -3,13 +3,14 @@
 -- SPDX-License-Identifier: Apache-2.0
 --
 
-daml 1.2
+{-# LANGUAGE ApplicativeDo #-}
 
 module Test.Test where
 
-import DA.Assert 
+import DA.Assert
 import DA.Date
 import DA.Time
+import Daml.Script
 import Actors.Compliance
 import Actors.DeskHead
 import Actors.Operator
@@ -20,101 +21,13 @@ import Desk.Limit
 import Transfer.Address
 import Transfer.Request
 import Transfer.Transfer
+import Test.OnboardingScript
 
-satoshiLimit : Satoshi
-satoshiLimit = Satoshi 100_000_000
-
-data ScenarioPartiesHelper = ScenarioPartiesHelper with
-  operator : Party
-  trader : Party
-  deskHead : Party
-  signingParty : Party
-  complianceOfficer: Party
-
-
-data ScenarioContractsHelper = ScenarioContractsHelper with 
-  oemCid: ContractId OnboardEntityMaster
-  complCid: ContractId ComplianceRole
-  signCid: ContractId SigningPartyRole
-  deskHeadCid: ContractId DeskHeadRole
-  traderCid: ContractId TraderRole
-  limitCid: ContractId TransferLimit
-  addressCid: ContractId DestinationAddress
-  badAddressCid: ContractId DestinationAddress
-
-onboarding = scenario do
-
-  operator <- getParty "Operator"
-  trader1 <- getParty "Trader1"
-  trader2 <- getParty "Trader2"
-  deskHead <- getParty "DeskHead"
-  signingParty <- getParty "SigningParty"
-  complianceOfficer <- getParty "ComplianceOfficer"
-
-  let deskName = "Crypto Asset Management Group"
-  let address = BitcoinAddress "muDrC4zKYrp2563QefqhZZ2ymWh2iVYa6F"
-  let ownedAddress1 = BitcoinAddress "mogSS38Q48CUS5kLXc6z6CzjampdeTd2Q8"
-  let ownedAddress2 = BitcoinAddress "mmgZZMGKRAM9C8ySTnwrWaGwYwgdidEhWe"
-  let badAddress1 = BitcoinAddress "1Py3BhtZcYX7vcEuSxKWoTKaitkjLwZC1n"
-
-  -- Genesis Contract
-  oemCid <- submit operator $ create OnboardEntityMaster with operator
-
-  -- Onboard Compliance
-  complInvCid <- operator `submit` exercise oemCid InviteCompliance with complianceOfficer
-  complCid <- complianceOfficer `submit` exercise complInvCid AcceptComplianceInvitation
-
-  -- Onboard Signing Party
-  signInvCid <- operator `submit` exercise oemCid InviteSigningParty with signingParty
-  signCid <- signingParty `submit` exercise signInvCid AcceptSigningPartyInvitation
-
-  -- Onboard Desk
-  deskInvCid <- operator `submit` exercise complCid InviteDeskHead with deskHead; deskName
-  deskRes <- deskHead `submit` exercise deskInvCid AcceptDeskInvitation
-  let deskCid = fst deskRes
-  let deskHeadCid = snd deskRes
-
-  -- Register Addresses
-  addressCid <- complianceOfficer `submit` exercise complCid RegisterNewAddress with address; reputation = Good; tag = "This is a good address. Believe me."
-  ownedAddressCid1 <- complianceOfficer `submit` exercise complCid RegisterNewAddress with address = ownedAddress1; reputation = Good; tag = "My fellow counterparty"
-  ownedAddressCid2 <- complianceOfficer `submit` exercise complCid RegisterNewAddress with address = ownedAddress2; reputation = Good; tag = "Some other trading house"
-  badAddressCid <- complianceOfficer `submit` exercise complCid RegisterNewAddress with address = badAddress1; reputation = Bad; tag = "Bad! Avoid at all cost!"
-
-  -- Onbard Traders to Desk
-  trdrInvCid <- deskHead `submit` exercise deskHeadCid AddTraderToDesk with trader = trader1; deskCid
-  trdrRes <- trader1 `submit` exercise trdrInvCid AcceptTraderInvitation
-  let trdr1Cid = fst trdrRes
-  let deskCid2 = snd trdrRes
-  trdrInvCid <- deskHead `submit` exercise deskHeadCid AddTraderToDesk with trader = trader2; deskCid = deskCid2
-  trdrRes <- trader2 `submit` exercise trdrInvCid AcceptTraderInvitation
-  let trdr2Cid = fst trdrRes
-  let deskCid = snd trdrRes
-
-  -- Add traders as observers to company owned address
-  addressCid <- complianceOfficer `submit` exercise complCid AddObserverToAddress with newObserver = trader1; addressCid = addressCid
-  ownedAddressCid1 <- complianceOfficer `submit` exercise complCid AddObserverToAddress with newObserver = trader1; addressCid = ownedAddressCid1
-  ownedAddressCid2 <- complianceOfficer `submit` exercise complCid AddObserverToAddress with newObserver = trader1; addressCid = ownedAddressCid2
-  badAddressCid <- complianceOfficer `submit` exercise complCid AddObserverToAddress with newObserver = trader1; addressCid = badAddressCid
-
-  -- Add desk head as observers to company owned address
-  addressCid <- complianceOfficer `submit` exercise complCid AddObserverToAddress with newObserver = deskHead, addressCid = addressCid
-  ownedAddressCid1 <- complianceOfficer `submit` exercise complCid AddObserverToAddress with newObserver = deskHead, addressCid = ownedAddressCid1
-  ownedAddressCid2 <- complianceOfficer `submit` exercise complCid AddObserverToAddress with newObserver = deskHead, addressCid = ownedAddressCid2
-  badAddressCid <- complianceOfficer `submit` exercise complCid AddObserverToAddress with newObserver = deskHead, addressCid = badAddressCid
-
-  -- Issue Desk Limits
-  limitCid <- deskHead `submit` exercise deskHeadCid IssueTransferLimit with dayLimit = satoshiLimit
-  
-  let parties = ScenarioPartiesHelper operator trader1 deskHead signingParty complianceOfficer
-  let contracts = ScenarioContractsHelper oemCid complCid signCid deskHeadCid trdr1Cid limitCid addressCid badAddressCid
-  return (parties, contracts, address, badAddress1)
-
-
-getTransferAndUTXO : ScenarioPartiesHelper -> ScenarioContractsHelper -> BitcoinAddress -> Satoshi -> Satoshi -> Scenario (ContractId UncheckedTransferRequest, ContractId UTXO)
-getTransferAndUTXO parties contracts address satoshiAmount fee = scenario do
+getTransferAndUTXO : ScriptPartiesHelper -> ScriptContractsHelper -> BitcoinAddress -> Satoshi -> Satoshi -> Script (ContractId UncheckedTransferRequest, ContractId UTXO)
+getTransferAndUTXO parties contracts address satoshiAmount fee = script do
 
   -- Create a UTXO and update the balance at owned address accordingly
-  ownedAddressCid <- parties.signingParty `submit` exercise contracts.signCid RegisterOwnedAddress with address = address
+  ownedAddressCid <- parties.signingParty `submit` exerciseCmd contracts.signCid RegisterOwnedAddress with address = address
   let utxoData = UTXOData with
                    address = address
                    txHash = TxHash "some tx hash"
@@ -123,46 +36,45 @@ getTransferAndUTXO parties contracts address satoshiAmount fee = scenario do
                    value = satoshiAmount `plus` fee
                    confirmed = Some (time (date 2019 Aug 22) 0 0 0)
                    sigScript = ScriptPubKey "some sig script"
+  reqUTXOUpdateCid <- submit parties.operator do
+    exerciseCmd contracts.oemCid RequestUTXOUpdate
   utxoCid <- parties.operator `submit` do
-    reqUTXOUpdateCid <- exercise contracts.oemCid RequestUTXOUpdate
-    utxoCid <- exercise contracts.oemCid RegisterUTXO with utxoData = utxoData
-    exercise ownedAddressCid UpdateBalance with
+    utxoCid <- exerciseCmd contracts.oemCid RegisterUTXO with utxoData = utxoData
+    exerciseCmd ownedAddressCid UpdateBalance with
       newBalance = satoshiAmount
       newNumTxs = 2
-    exercise reqUTXOUpdateCid AckUTXOUpdateRequest
+    exerciseCmd reqUTXOUpdateCid AckUTXOUpdateRequest
     return utxoCid
 
   -- Get a new transfer request
   transferRequestCid <-
-    parties.trader `submit` exercise contracts.traderCid
+    parties.trader `submit` exerciseCmd contracts.traderCid
       RequestTransfer with
         amount = satoshiAmount
         address = address
 
   return (transferRequestCid, utxoCid)
 
-transmit : ScenarioPartiesHelper -> ScenarioContractsHelper -> ContractId ValidatedTransferRequest -> Satoshi -> ContractId UTXO -> Scenario (Either InsufficientTransferRequest TransmittedTransfer)
-transmit parties contracts transferRequestCid fee utxoCid = scenario do
-  transferCid1 <- parties.operator `submit` exercise transferRequestCid PrepareToTransfer with
+transmit : ScriptPartiesHelper -> ScriptContractsHelper -> ContractId ValidatedTransferRequest -> Satoshi -> ContractId UTXO -> Script (Either InsufficientTransferRequest TransmittedTransfer)
+transmit parties contracts transferRequestCid fee utxoCid = script do
+  transferCid1 <- parties.operator `submit` exerciseCmd transferRequestCid PrepareToTransfer with
       signingPartyCid = contracts.signCid
       fee = fee
       availableTxInputCids = [utxoCid]
   case transferCid1 of
     Right newTransferCid -> do
-      transferCid2 <- parties.signingParty `submit` exercise newTransferCid SignTransfer with
+      transferCid2 <- parties.signingParty `submit` exerciseCmd newTransferCid SignTransfer with
         rawTx = RawTx "some raw Tx"
-      transferCid3 <- parties.trader `submit` exercise transferCid2 Confirm
-      transferCid4 <- parties.operator `submit` exercise transferCid3 Transmit with
+      transferCid3 <- parties.trader `submit` exerciseCmd transferCid2 Confirm
+      transferCid4 <- parties.operator `submit` exerciseCmd transferCid3 Transmit with
         message = "finalized"
-      submit parties.operator do
-        transfer <- fetch transferCid4
-        Right <$> return transfer
+      Some transfer <- queryContractId parties.operator transferCid4
+      Right <$> return transfer
     Left insufficientTransferRequestCid -> do
-      submit parties.operator do
-        transfer2 <- fetch insufficientTransferRequestCid
-        Left <$> return transfer2
+      Some transfer2 <- queryContractId parties.operator insufficientTransferRequestCid
+      Left <$> return transfer2
 
-simpleSuccessfulTransfer = scenario do
+simpleSuccessfulTransfer = script do
   let fee = Satoshi 1
   let satoshiAmount = Satoshi 500
 
@@ -170,7 +82,7 @@ simpleSuccessfulTransfer = scenario do
 
   (uncheckedTransferRequestCid, utxoCid) <- getTransferAndUTXO parties contracts address satoshiAmount fee
 
-  transferRequestResult <- parties.operator `submit` exercise uncheckedTransferRequestCid ValidateRequest
+  transferRequestResult <- parties.operator `submit` exerciseCmd uncheckedTransferRequestCid ValidateRequest
 
   transferRequestCid1 <- case transferRequestResult of
       LimitFail _ -> fail "expected successful address check, but got address problems"
@@ -183,7 +95,7 @@ simpleSuccessfulTransfer = scenario do
       Left insufficientTransferRequest -> insufficientTransferRequest.transferDetails
   details.amount === satoshiAmount
 
-overrideFailedChecksAndTransmit = scenario do
+overrideFailedChecksAndTransmit = script do
   let
     fee = Satoshi 1
     satoshiAmount = satoshiLimit `plus` fee `plus` (Satoshi 1)
@@ -192,20 +104,20 @@ overrideFailedChecksAndTransmit = scenario do
 
   (uncheckedTransferRequestCid, utxoCid) <- getTransferAndUTXO parties contracts badAddress satoshiAmount fee
 
-  transferRequestResult <- parties.operator `submit` exercise uncheckedTransferRequestCid ValidateRequest
+  transferRequestResult <- parties.operator `submit` exerciseCmd uncheckedTransferRequestCid ValidateRequest
 
   failedRequestCid1 <- case transferRequestResult of
     LimitFail failedRequestCid1 -> pure failedRequestCid1
     ReputationFail _ -> fail "expected failure due to limit violation, but limit check successfully passed"
     ValidationSuccess _ -> fail "expected failure due to limit and address violation, but both checks successfully passed"
-  (limitOverride, _) <- parties.deskHead `submit` exercise contracts.deskHeadCid ApproveRequestOverLimits with
+  (limitOverride, _) <- parties.deskHead `submit` exerciseCmd contracts.deskHeadCid ApproveRequestOverLimits with
     failedRequestCid = failedRequestCid1
     reason = "Desk head overrides limit failure"
     observers = []
   failedAddressCheckCid <- case limitOverride of
     Right _ -> fail "expected failure due to bad address, but address check successfully passed"
     Left failedAddressCheckCid -> pure failedAddressCheckCid
-  (addressOverride, _) <- parties.complianceOfficer `submit` exercise contracts.complCid ApproveRequestToBadAddress with
+  (addressOverride, _) <- parties.complianceOfficer `submit` exerciseCmd contracts.complCid ApproveRequestToBadAddress with
         failedRequestCid = failedAddressCheckCid
         reason = "Compliance officer trusts this address"
         observers = []
@@ -216,79 +128,89 @@ overrideFailedChecksAndTransmit = scenario do
       Left insufficientTransferRequest -> insufficientTransferRequest.transferDetails
   details.amount === satoshiAmount
 
-validTransferIncreasesLimitUsage = scenario do
+validTransferIncreasesLimitUsage = script do
   let fee = Satoshi 1
       goodAmount = Satoshi 1000
   (parties, contracts, goodAddress, _) <- onboarding
 
   (transferRequestCid, utxoCid) <- getTransferAndUTXO parties contracts goodAddress goodAmount fee
 
-  transferRequestResult <- parties.operator `submit` exercise transferRequestCid ValidateRequest
+  transferRequestResult <- parties.operator `submit` exerciseCmd transferRequestCid ValidateRequest
 
   requestCid <- case transferRequestResult of
     ValidationSuccess requestCid -> pure requestCid
     LimitFail _ -> fail "expected transfer request to be valid, but failed limit check"
     ReputationFail _ -> fail "expected transfer request to be valid, but failed address check"
-  parties.operator `submit` exercise requestCid PrepareToTransfer with
+  parties.operator `submit` exerciseCmd requestCid PrepareToTransfer with
     signingPartyCid = contracts.signCid
     fee = fee
     availableTxInputCids = [utxoCid]
   newLimit <- findNewLimit parties contracts
   newLimit.used === goodAmount `plus` fee
 
-overLimitTransferIncreasesLimitUsage = scenario do
+overLimitTransferIncreasesLimitUsage = script do
   let fee = Satoshi 1
       overLimitAmount = satoshiLimit `plus` Satoshi 1000
   (parties, contracts, goodAddress, _) <- onboarding
 
   (transferRequestCid, utxoCid) <- getTransferAndUTXO parties contracts goodAddress overLimitAmount fee
 
-  transferRequestResult <- parties.operator `submit` exercise transferRequestCid ValidateRequest
+  transferRequestResult <- parties.operator `submit` exerciseCmd transferRequestCid ValidateRequest
 
   failedRequestCid <- case transferRequestResult of
     LimitFail failedRequestCid -> pure failedRequestCid
     ValidationSuccess _ -> fail "expected failure due to limit violation, but limit check successfully passed"
     ReputationFail _ -> fail "expected transfer request to be valid, but failed address check"
-  (approvedRequestCid, _) <- parties.deskHead `submit` exercise contracts.deskHeadCid ApproveRequestOverLimits with
+  (approvedRequestCid, _) <- parties.deskHead `submit` exerciseCmd contracts.deskHeadCid ApproveRequestOverLimits with
     failedRequestCid = failedRequestCid
     reason = "Desk head overrides limit failure"
     observers = []
   validRequestCid <- case approvedRequestCid of
     Right validRequestCid -> pure validRequestCid
-    otherwise -> fail "expected transfer request to be valid, but failed address check"
-  parties.operator `submit` exercise validRequestCid PrepareToTransfer with
+    _ -> fail "expected transfer request to be valid, but failed address check"
+  parties.operator `submit` exerciseCmd validRequestCid PrepareToTransfer with
     signingPartyCid = contracts.signCid
     fee = fee
     availableTxInputCids = [utxoCid]
   newLimit <- findNewLimit parties contracts
   newLimit.used === overLimitAmount `plus` fee
 
-badAddressTransferIncreasesLimitUsage = scenario do
+badAddressTransferIncreasesLimitUsage = script do
   let fee = Satoshi 1
       overLimitAmount = Satoshi 1000
   (parties, contracts, _, badAddress) <- onboarding
 
   (transferRequestCid, utxoCid) <- getTransferAndUTXO parties contracts badAddress overLimitAmount fee
 
-  transferRequestResult <- parties.operator `submit` exercise transferRequestCid ValidateRequest
+  transferRequestResult <- parties.operator `submit` exerciseCmd transferRequestCid ValidateRequest
 
   failedRequestCid <- case transferRequestResult of
     ReputationFail failedRequestCid -> pure failedRequestCid
     ValidationSuccess _ -> fail "expected failure due to limit violation, but limit check successfully passed"
     LimitFail _ -> fail "expected transfer request to be within limit, but limit check failed"
-  (approvedRequestCid, _) <- parties.complianceOfficer `submit` exercise contracts.complCid ApproveRequestToBadAddress with
+  (approvedRequestCid, _) <- parties.complianceOfficer `submit` exerciseCmd contracts.complCid ApproveRequestToBadAddress with
     failedRequestCid = failedRequestCid
     reason = "Compliance officer trusts this address"
     observers = []
-  parties.operator `submit` exercise approvedRequestCid PrepareToTransfer with
+  parties.operator `submit` exerciseCmd approvedRequestCid PrepareToTransfer with
     signingPartyCid = contracts.signCid
     fee = fee
     availableTxInputCids = [utxoCid]
   newLimit <- findNewLimit parties contracts
   newLimit.used === overLimitAmount `plus` fee
 
-findNewLimit : ScenarioPartiesHelper -> ScenarioContractsHelper -> Scenario TransferLimit
-findNewLimit parties contracts = scenario do
-  deskHeadRole <- parties.operator `submit` fetch contracts.deskHeadCid
-  (_, newLimit) <- parties.operator `submit` fetchByKey @TransferLimit (parties.operator, parties.deskHead, deskHeadRole.deskName)
+findNewLimit : ScriptPartiesHelper -> ScriptContractsHelper -> Script TransferLimit
+findNewLimit parties contracts = script do
+  Some deskHeadRole <- queryContractId parties.operator contracts.deskHeadCid
+  (_, newLimit) <- parties.operator `submit` createAndExerciseCmd (Helper parties.operator) (FetchTransferLimitByKey (parties.operator, parties.deskHead, deskHeadRole.deskName))
   pure newLimit
+
+template Helper
+  with
+    p : Party
+  where
+    signatory p
+    choice FetchTransferLimitByKey : (ContractId TransferLimit, TransferLimit)
+      with k : (Party, Party, Text)
+      controller p
+      do fetchByKey @TransferLimit k


### PR DESCRIPTION
In SDK 1.5.0 (and recent snapshots as the one used in this PR), DAML
Script is executed in DAML Studio and as part of `daml test` and we
are planning to deprecate scenarios so we are migrating over all
examples.

Happy to wait until SDK 1.5.0 before we merge this.

This is also a great example for why we did this: It allows us to kill
the whole duplication between the scenario and the script.